### PR TITLE
Update hash to current `common-definitions`

### DIFF
--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -5,7 +5,7 @@ dimensions:
 repositories:
   common-definitions:
     url: https://github.com/IAMconsortium/common-definitions.git/
-    hash: d15f81a1c9670ddf6562aaa9a88224ba716f1ac9
+    hash: 70c5262068fcf85e03bab7684fa30bae2a1ca8a8
 definitions:
   variable:
     repository: common-definitions


### PR DESCRIPTION
This puts the ssp-submission-workflow in sync with common-definitions.
It does not automatically update to future changes in common-definitions. 

So, the suggested workflow for now (in discussion with @volker-krey) is to just update this hash regularly, when we want to update it, but not have unexpected changes from common-definitions affect the ssp-submission-workflow for ScenarioMIP.

The way that we could decide to update is: "whenever there's a consensus among ScenarioMIP coordinators".
