### PR TITLE
Rename dimensionless variables to `-`

### DIFF
--- a/workflow.py
+++ b/workflow.py
@@ -38,6 +38,11 @@ def main(df: pyam.IamDataFrame) -> pyam.IamDataFrame:
             dsd=dsd,
         ),
     )
+
+    # Quickfix: make dimensionless variables (unit="") work with legacy ixmp database
+    df.rename(unit={"": "-"}, inplace=True)
+
+    # Run MAGICC processing if available
     if FOUND_MAGICC:
         magicc_processor = MAGICCProcessor(
             run_type="complete",


### PR DESCRIPTION
This is a quickfix for an issue reported by Laurin Koehle - **common-definitions** uses `unit=None` for dimensionless variables, which is translated by **pyam** to `unit=""`, but this only works with **ixmp4** databases, not with legacy **ixmp** databases.

This fix should be removed when migrating the SSP-Submisson Scenario Explorer to an **ixmp4** instance.