### PR TITLE
Update scenario names according to latest naming in ScenarioMIP paper

### DIFF
--- a/definitions/scenario/tag_scenario_mip.yaml
+++ b/definitions/scenario/tag_scenario_mip.yaml
@@ -1,7 +1,13 @@
 - ScenarioMIP:
-    - High Emissions
-    - Medium Emissions
-    - Medium-Low Emissions
-    - Low Emissions
-    - Very Low with Limited Overshoot
-    - Very Low after High Overshoot
+    - H:
+        description: "High Emissions"
+    - M:
+        description: "Medium Emissions"
+    - ML:
+        description: "Medium-Low Emissions"
+    - L:
+        description: "Low Emissions"
+    - VLLO:
+        description: "Very Low with Limited Overshoot"
+    - VLHO:
+        description: "Very Low after High Overshoot"

--- a/definitions/scenario/tag_scenario_mip.yaml
+++ b/definitions/scenario/tag_scenario_mip.yaml
@@ -3,6 +3,5 @@
     - Medium Emissions
     - Medium-Low Emissions
     - Low Emissions
-    - Very Low Emissions
-    - Medium Overshoot
-    - Low Overshoot
+    - Very Low with Limited Overshoot
+    - Very Low after High Overshoot

--- a/definitions/scenario/tag_scenario_mip.yaml
+++ b/definitions/scenario/tag_scenario_mip.yaml
@@ -1,6 +1,8 @@
 - ScenarioMIP:
     - H:
         description: "High Emissions"
+    - HL:
+        description: "High-Low Emissions"
     - M:
         description: "Medium Emissions"
     - ML:

--- a/definitions/scenario/tag_scenario_mip.yaml
+++ b/definitions/scenario/tag_scenario_mip.yaml
@@ -1,7 +1,13 @@
 - ScenarioMIP:
-    - High Emissions
-    - Medium Emissions
-    - Medium-Low Emissions
-    - Low Emissions
-    - Very Low with Limited Overshoot
-    - Very Low after High Overshoot
+    - H
+        description: "High Emissions"
+    - M
+        description: "Medium Emissions"
+    - ML
+        description: "Medium-Low Emissions"
+    - L
+        description: "Low Emissions"
+    - VLLO
+        description: "Very Low with Limited Overshoot"
+    - VLHO
+        description: "Very Low after High Overshoot"


### PR DESCRIPTION
In light of the new names for the six scenarios (see ScenarioMIP paper https://egusphere.copernicus.org/preprints/2025/egusphere-2024-3765/), I suggest to update the scenario names. 

In the December 2024 submission, this had let to confusion as different teams had different interpretations of the correspondence between the new names (Very Low after High Overshoot, Very Low with Limited Overshoot) and the old names (Very Low, Low Overshoot).

Moreover, I suggest to remove the old scenario name Medium Overshoot.

@danielhuppmann, @phackstock : Does that make sense to you? Or does it create problems with the existing uploads to the IIASA database? Thanks!