### PR TITLE
Add 'Regional Organizations' to nomenclature hierarchy

### DIFF
--- a/nomenclature.yaml
+++ b/nomenclature.yaml
@@ -17,6 +17,7 @@ definitions:
         - hierarchy: R9
         - hierarchy: R10
         - hierarchy: G20 Members
+        - hierarchy: Regional Organizations
         - hierarchy: MESSAGEix-GLOBIOM 2.1-R12
         - hierarchy: AIM 3.0
         - hierarchy: COFFEE 1.6


### PR DESCRIPTION
This is to preempt mapping-issues after merging https://github.com/IAMconsortium/common-definitions/pull/346